### PR TITLE
Avoid that locally missing images blocks global search movies navigat…

### DIFF
--- a/channels/biblioteca.py
+++ b/channels/biblioteca.py
@@ -133,14 +133,14 @@ def mainlist(item):
                      url="tv/on_the_air?",
                      plot="1",
                      thumbnail="https://i.imgur.com/2ZWjLn5.jpg?1"),
-		 
+
                 Item(channel=__channel__,
                      title="(TV Shows) [COLOR lime]Populars[/COLOR]",
                      action="list_tvshow",
                      url="tv/popular?",
                      plot="1",
                      thumbnail="https://i.imgur.com/2ZWjLn5.jpg?1"),
-          
+
                 Item(channel=__channel__,
                      title="(TV Shows) [COLOR lime]Top Rated[/COLOR]",
                      action="list_tvshow",
@@ -425,16 +425,26 @@ def build_movie_list(item, movies):
             logger.info('streamondemand.database set for local playing(%s):\n%s' % (title, str(kodi_db_movie)))
             if year == str(kodi_db_movie["year"]):
                 found = True
+
+                # If some, less relevant, keys are missing locally
+                # try to get them through TMDB anyway.
+                try:
+                    poster = kodi_db_movie["art"]["poster"]
+                    fanart = kodi_db_movie["art"]["fanart"]
+                except KeyError:
+                    poster = poster
+                    fanart = fanart
+
                 itemlist.append(Item(
                         channel=item.channel,
                         action='play',
                         url=kodi_db_movie["file"],
                         title='[COLOR orange][%s][/COLOR] ' % NLS_Library + kodi_db_movie["title"] + jobrole,
-                        thumbnail=kodi_db_movie["art"]["poster"],
+                        thumbnail=poster,
                         category=genres,
                         plot=plot,
                         viewmode='movie_with_plot',
-                        fanart=kodi_db_movie["art"]["fanart"],
+                        fanart=fanart,
                         extrameta=extrameta,
                         extracmds=extracmds,
                         folder=False,


### PR DESCRIPTION
Hello!

We found a bug while navigating the _global search_, where if a movie was found locally and it had some problems with missing fanart or poster, an error was generated making impossible to go on navigating other pages.

The fix simply adds a `try` statement to manage that particular situation.

Hope it helps!